### PR TITLE
Add operator overloads

### DIFF
--- a/SingleSignOn.podspec
+++ b/SingleSignOn.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "SingleSignOn"
-  s.version         = "1.0.1"
+  s.version         = "1.0.2"
   s.summary         = "Library to interface with RedHat SSO"
   s.description     = "This pod contains various components to support authentication and credential managment"
   s.homepage        = "http://pathfinder.gov.bc.ca"

--- a/SingleSignOn/UI/AuthenticationError.swift
+++ b/SingleSignOn/UI/AuthenticationError.swift
@@ -30,3 +30,22 @@ public enum AuthenticationError: Error {
     case expired
     case webRequestFailed(error: Error)
 }
+
+/// Returns a Boolean indicating whether the errors are identical.
+public func == (lhs: Error, rhs: AuthenticationError) -> Bool {
+    return lhs._code == rhs._code
+        && lhs._domain == rhs._domain
+}
+
+
+/// Returns a Boolean indicating whether the errors are identical.
+public func == (lhs: AuthenticationError, rhs: Error) -> Bool {
+    return lhs._code == rhs._code
+        && lhs._domain == rhs._domain
+}
+
+/// Returns a Boolean indicating whether the errors are identical.
+public func == (lhs: AuthenticationError, rhs: AuthenticationError) -> Bool {
+    return lhs._code == rhs._code
+        && lhs._domain == rhs._domain
+}


### PR DESCRIPTION
This was working for me because it was finding patching operator overloads for '==' from Realm. I've added the three overloads I think we need. I'll see if I can clean this up a bit using Generics so I don't have to repeat the code.