### PR TITLE
Revert overload

### DIFF
--- a/SingleSignOn.podspec
+++ b/SingleSignOn.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "SingleSignOn"
-  s.version         = "1.0.2"
+  s.version         = "1.0.3"
   s.summary         = "Library to interface with RedHat SSO"
   s.description     = "This pod contains various components to support authentication and credential managment"
   s.homepage        = "http://pathfinder.gov.bc.ca"

--- a/SingleSignOn/UI/AuthenticationError.swift
+++ b/SingleSignOn/UI/AuthenticationError.swift
@@ -30,22 +30,3 @@ public enum AuthenticationError: Error {
     case expired
     case webRequestFailed(error: Error)
 }
-
-/// Returns a Boolean indicating whether the errors are identical.
-public func == (lhs: Error, rhs: AuthenticationError) -> Bool {
-    return lhs._code == rhs._code
-        && lhs._domain == rhs._domain
-}
-
-
-/// Returns a Boolean indicating whether the errors are identical.
-public func == (lhs: AuthenticationError, rhs: Error) -> Bool {
-    return lhs._code == rhs._code
-        && lhs._domain == rhs._domain
-}
-
-/// Returns a Boolean indicating whether the errors are identical.
-public func == (lhs: AuthenticationError, rhs: AuthenticationError) -> Bool {
-    return lhs._code == rhs._code
-        && lhs._domain == rhs._domain
-}


### PR DESCRIPTION
I think adding the operator overloads isn't the best way to check for specific errors. Better to use code like this:

`
if let error = error as? AuthenticationError, case .expired = error { }
`
