### PR TITLE
Fix missing token_id property

### DIFF
--- a/SingleSignOn.podspec
+++ b/SingleSignOn.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "SingleSignOn"
-  s.version         = "1.0.5"
+  s.version         = "1.0.6"
   s.summary         = "Library to interface with RedHat SSO"
   s.description     = "This pod contains various components to support authentication and credential managment"
   s.homepage        = "http://pathfinder.gov.bc.ca"

--- a/SingleSignOn/Model/Credentials.swift
+++ b/SingleSignOn/Model/Credentials.swift
@@ -31,7 +31,6 @@ public struct Credentials {
     internal let refreshExpiresIn: Int
     internal let refreshExpiresAt: Date
     internal let notBeforePolicy: Int
-    internal let tokenId: String
     internal let expiresIn: Int
     internal let expiresAt: Date
     internal let props: [String : Any]
@@ -65,15 +64,13 @@ public struct Credentials {
     
     
     init(withJSON data: [String: Any]) {
-        
-        
+
         tokenType = data["token_type"] as! String
         refreshToken = data["refresh_token"] as! String
         accessToken = data["access_token"] as! String
         sessionState = data["session_state"] as! String
         refreshExpiresIn = data["refresh_expires_in"] as! Int   // in sec
         notBeforePolicy = data["not-before-policy"] as! Int
-        tokenId = data["id_token"] as! String
         expiresIn = data["expires_in"] as! Int                  // in sec
         
         // If we are loading credentials from the keychain we will have two additional fields representing when the
@@ -87,7 +84,7 @@ public struct Credentials {
         }
 
         // Used to serialize this object so it can be stored in the keychian
-        props = ["token_type": tokenType, "refresh_token": refreshToken, "access_token": accessToken, "session_state": sessionState, "refresh_expires_in": refreshExpiresIn, "not-before-policy": notBeforePolicy, "id_token": tokenId, "expires_in": expiresIn, "refreshExpiresAt": Credentials.dateToString(date: refreshExpiresAt), "expiresAt": Credentials.dateToString(date: expiresAt)]
+        props = ["token_type": tokenType, "refresh_token": refreshToken, "access_token": accessToken, "session_state": sessionState, "refresh_expires_in": refreshExpiresIn, "not-before-policy": notBeforePolicy, "expires_in": expiresIn, "refreshExpiresAt": Credentials.dateToString(date: refreshExpiresAt), "expiresAt": Credentials.dateToString(date: expiresAt)]
 
         save()
     }

--- a/SingleSignOn/Services/AuthServices.swift
+++ b/SingleSignOn/Services/AuthServices.swift
@@ -102,7 +102,7 @@ public class AuthServices: NSObject {
         guard let credentials = credentials else {
             return
         }
-        
+
         credentials.remove();
         self.credentials = nil
     }

--- a/SingleSignOn/UI/AuthViewController.swift
+++ b/SingleSignOn/UI/AuthViewController.swift
@@ -123,18 +123,13 @@ public class AuthViewController: UIViewController {
     
     private func extractCode(from url: URL) -> String? {
         
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+        let key = "code"
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true), let items = components.queryItems,
+            let code = items.first(where: { $0.name == key })?.value else {
             return nil
         }
         
-        if let query = components.query {
-            let results = query.split(separator: "=")
-            if let key = results.first, let value = results.last, String(describing: key) == responseType {
-                return String(describing: value)
-            }
-        }
-        
-        return nil
+        return code
     }
     
     private func handelCustomRedirect(url: URL) {


### PR DESCRIPTION
The token_id property was removed in this last release of SSO; I updated the code previously but the changes was lost at some point; perhaps during some cleanup I did. This PR re-implements the fix.